### PR TITLE
Use older type annotation syntax to be compatible with Python 3.9

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -8,11 +8,22 @@ steps:
           entrypoint: "" # Override: https://github.com/cytopia/docker-mypy/blob/f33fba854ea69a4fd102a044242c2a3c8efac6e3/Dockerfiles/Dockerfile.python3.10#L51
           shell: ["/bin/sh", "-e", "-c"] # Restore default from setting `entrypoint:` above.
 
-  - label: ":python: Unit tests"
-    command: "python3 -m unittest tests/*.py"
-    plugins:
-      - docker#v5.11.0:
-          image: "python:3.10-alpine"
+  - group: ":python: Unit tests"
+    steps:
+      - name: ":python: Unit Test (Python {{matrix.python_version}})"
+        command: "python3 -m unittest tests/*.py"
+        plugins:
+          - docker#v5.11.0:
+              image: "python:{{matrix.python_version}}-alpine"
+        matrix:
+          setup:
+            python_version:
+              - "3.9"
+              - "3.10"
+              - "3.11"
+              - "3.12"
+              - "3.13-rc"
+
   - label: ":sparkles: Lint"
     plugins:
       - plugin-linter#v3.3.0:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This plugin authenticates with Buildkite Packages using an [Agent OIDC token](ht
 steps:
   - label: "Publish Gem"
     plugins:
-      - publish-to-packages#v2.1.0:
+      - publish-to-packages#v2.2.0:
           artifacts: "awesome-logger-*.gem"
           registry: "acme-corp/awesome-logger"
 ```
@@ -23,7 +23,7 @@ steps:
 steps:
   - label: "Publish Gem"
     plugins:
-      - publish-to-packages#v2.1.0:
+      - publish-to-packages#v2.2.0:
           artifacts: "awesome-logger-*.gem"
           registry: "acme-corp/awesome-logger"
           attestations: # optional
@@ -81,7 +81,7 @@ steps:
   - label: "Publish Gem"
     depends_on: "build-gem"
     plugins:
-      - publish-to-packages#v2.1.0:
+      - publish-to-packages#v2.2.0:
           artifacts: "awesome-logger-*.gem" # publish from build artifact storage
           registry: "acme-corp/awesome-logger"
 ```
@@ -121,7 +121,7 @@ steps:
 steps:
   - label: "Publish Gem"
     plugins:
-      - publish-to-packages#v2.1.0:
+      - publish-to-packages#v2.2.0:
           artifacts: "awesome-logger-*.gem"
           registry: "acme-corp/awesome-logger"
           artifact_build_id: "${BUILDKITE_TRIGGERED_FROM_BUILD_ID}"
@@ -143,7 +143,7 @@ steps:
   - label: "Publish Gem"
     depends_on: "build-gem"
     plugins:
-      - publish-to-packages#v2.1.0:
+      - publish-to-packages#v2.2.0:
           artifacts: "awesome-logger-*.gem" # publish from build artifact storage
           registry: "acme-corp/awesome-logger"
           attestations: "gem-build.attestation.json"

--- a/package_publisher/core.py
+++ b/package_publisher/core.py
@@ -1,11 +1,11 @@
 import json
 import subprocess
-from typing import Any
+from typing import Any, Optional
 
 
 class PackagePublisher:
     def __init__(
-        self, registry: str, attestation_bundle_path: str | None = None
+        self, registry: str, attestation_bundle_path: Optional[str] = None
     ) -> None:
         (self.organization_slug, self.registry_slug) = registry.split("/")
         self.attestation_bundle_path = attestation_bundle_path

--- a/package_publisher/helpers.py
+++ b/package_publisher/helpers.py
@@ -1,9 +1,10 @@
 import json
 
 from tempfile import NamedTemporaryFile
+from typing import Optional
 
 
-def attestations_to_bundle(file_paths: list[str]) -> str | None:
+def attestations_to_bundle(file_paths: list[str]) -> Optional[str]:
     if len(file_paths) <= 0:
         return None
 


### PR DESCRIPTION
The pipe operator `|` for expressing union types was only introduced in Python 3.10. 

This PR replaces its use (e.g. `str | None`) with `Optional[str]` so the plugin does not error out when running in Python 3.9 (and potentially older).

The CI pipeline is also updated to run unit tests on a range of python versions to detect any compatibility issues in the future.